### PR TITLE
Replace createFromDate() with create()

### DIFF
--- a/src/Requests.php
+++ b/src/Requests.php
@@ -18,7 +18,7 @@ class Requests
 
     public static function getActions($year, $month)
     {
-        $start = Carbon::createFromDate($year, $month)->startOfMonth();
+        $start = Carbon::create($year, $month)->startOfMonth();
         $end = $start->copy()->addMonth();
         $res = DB::table('kpis_actions')->whereBetween('date', [$start, $end])->sum('value');
 
@@ -26,7 +26,7 @@ class Requests
     }
     public static function getVisits($year, $month)
     {
-        $start = Carbon::createFromDate($year, $month)->startOfMonth();
+        $start = Carbon::create($year, $month)->startOfMonth();
         $end = $start->copy()->addMonth();
         $res = DB::table('kpis_visits')->whereBetween('date', [$start, $end])->sum('value');
 

--- a/src/User.php
+++ b/src/User.php
@@ -9,8 +9,8 @@ class User
 {
     public static function getUser($year, $month)
     {
-        $first = Carbon::createFromDate($year, $month)->startOfMonth();
-        $last = $first->copy()->addMonth();
+        $first = Carbon::create($year, $month)->startOfMonth();
+        $last = $first->copy()->endOfMonth();
 
         return DB::table('kpis_users')
             ->whereBetween('date', [$first, $last])

--- a/tests/RequestsTest.php
+++ b/tests/RequestsTest.php
@@ -56,6 +56,12 @@ class RequestsTest extends TestCase
         $this->assertEquals(10, $count);
     }
 
+    public function testGetActionsOverflow()
+    {
+        Carbon::setTestNow(Carbon::parse('2024-07-31T05:45:23Z'));
+        $this->testGetActions();
+    }
+
     public function testGetVisits()
     {
         $date = Carbon::now()
@@ -68,5 +74,11 @@ class RequestsTest extends TestCase
         $count = Requests::getVisits($date->year, $date->month);
 
         $this->assertEquals(10, $count);
+    }
+
+    public function testGetVisitsOverflow()
+    {
+        Carbon::setTestNow(Carbon::parse('2024-07-31T05:45:23Z'));
+        $this->testGetVisits();
     }
 }

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -27,6 +27,12 @@ class UserTest extends TestCase
         $this->assertEquals(20, $count);
     }
 
+    public function testGetUserOverflow()
+    {
+        Carbon::setTestNow(Carbon::parse('2024-07-31T05:45:23Z'));
+        $this->testGetUser();
+    }
+
     public function testGetUniqueUser(){
         $date = Carbon::now()
             ->settings(['monthOverflow' => false])


### PR DESCRIPTION
When using createFromDate(), missing arguments are replaced by the current date/time. This could lead to a month overflow on some days. This uses create() instead and adds tests for the overflow case.

References https://github.com/biigle/core/pull/902